### PR TITLE
Replacing broken gif with fork me link

### DIFF
--- a/subnets.html
+++ b/subnets.html
@@ -541,7 +541,7 @@ If you wish to save this subnetting for later, bookmark <a href="subnets.html" i
 
 </td>
 <td align="right">
-<a href="http://www.sargasso.net/"><img src="http://noc.us.sargasso.net/neteng.gif" width="162" height="64" alt="Sargasso Networks" border="0"></a>
+<a href="https://github.com/davidc/subnets"><img alt="Fork me on GitHub" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_white_ffffff.png" style="right: 0;top: 0;position: absolute;" ></a>
 </td>
 </tr>
 </table>


### PR DESCRIPTION
It looks like neteng.gif isn't available from your site anymore. Is it okay to replace it with a fork me on github link?

Love this tool so much, thanks for sharing it!