### PR TITLE
Change shift left operator to exponent operator to avoid overflow

### DIFF
--- a/subnets.html
+++ b/subnets.html
@@ -340,7 +340,7 @@ function network_address(ip, mask)
 
 function subnet_addresses(mask)
 {
-  return 1<<(32-mask);
+  return 2**(32-mask);
 }
 
 function subnet_last_address(subnet, mask)


### PR DESCRIPTION
Large numbers of hosts (/0 and /1 subnets) are overflowing and showing as a negative number.  Changing 1<<(32-mask) to 2**(32-mask) causes JavaScript to calculate the integer properly.